### PR TITLE
Hide extra stats for mania

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
         </div>
       </div>
 
-      <div class="box-6">
+      <div class="box-6" x-show="currentGamemode == 3 || currentGamemode == 4">
         <!-- Current implementation for mania 4k/7k -->
         <!-- TODO: Add standard/taiko/catch here -->
         <div class="inner-box">


### PR DESCRIPTION
- For taiko overlay, we only need basic stats (OD/HP, SR, Length, BPM)
- Hide gamemode 3 and 4 fields since its for mania 4k/7k only (rice count, long notes count)